### PR TITLE
Ingestion/guards/formatting

### DIFF
--- a/src/db/populatedb.ts
+++ b/src/db/populatedb.ts
@@ -5,6 +5,7 @@ import { RootSpan } from "../types/types";
 
 export async function populateAllMockData() {
   await resetAnnotationTable(); //dev mode only
+  await resetRootSpansTable(); //dev mode only
   //await populateTracesTable();
   //await populateAnnotationsTable();
 }
@@ -37,6 +38,19 @@ const resetAnnotationTable = async (): Promise<void> => {
   await pool.query('BEGIN');
   try {
     await pool.query('DELETE FROM annotations');
+    await pool.query('COMMIT');
+  } catch (e) {
+    await pool.query('ROLLBACK');
+    throw e;
+  }
+};
+
+// dev mode only ... lets you easily start with new annotations each time
+const resetRootSpansTable = async (): Promise<void> => {
+  // Wrap in a transaction for safety
+  await pool.query('BEGIN');
+  try {
+    await pool.query('DELETE FROM root_spans');
     await pool.query('COMMIT');
   } catch (e) {
     await pool.query('ROLLBACK');

--- a/src/db/populatedb.ts
+++ b/src/db/populatedb.ts
@@ -5,8 +5,8 @@ import { RootSpan } from "../types/types";
 
 export async function populateAllMockData() {
   await resetAnnotationTable(); //dev mode only
-  await populateTracesTable();
-  await populateAnnotationsTable();
+  //await populateTracesTable();
+  //await populateAnnotationsTable();
 }
 
 export const populateRootSpansTable = async (rootSpans: RootSpan[]) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,7 +13,7 @@ async function startServer() {
     await populateRootSpansTable(rootSpans);
   }
 
-  await populateAllMockData();
+  //await populateAllMockData();
   app.listen(config.port, () => {
     console.log(`Server running on port ${config.port}`);
   });

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,7 @@ import fetchRootSpans from "./services/graphqlIngestion/fetchRootSpans";
 async function startServer() {
   await initializePostgres();
 
-  await populateAllMockData(); // resets annotations and rootspans
+  await populateAllMockData(); // DEV MODE - resets annotations and rootspans
 
   const rootSpans = await fetchRootSpans();
   if(rootSpans){

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,12 +8,14 @@ import fetchRootSpans from "./services/graphqlIngestion/fetchRootSpans";
 async function startServer() {
   await initializePostgres();
 
+  await populateAllMockData(); // resets annotations and rootspans
+
   const rootSpans = await fetchRootSpans();
   if(rootSpans){
     await populateRootSpansTable(rootSpans);
   }
 
-  //await populateAllMockData();
+  
   app.listen(config.port, () => {
     console.log(`Server running on port ${config.port}`);
   });

--- a/src/services/graphqlIngestion/fetchRootSpans.ts
+++ b/src/services/graphqlIngestion/fetchRootSpans.ts
@@ -36,7 +36,7 @@ const fetchRootSpans = async (projectName?: string): Promise<RootSpan[]> => {
     }`;
 
     // If projectName is empty it will retrieve all root spans!
-    const variables = projectName ? { projectName } : { projectName: "recipe-chatbot-oneTrace" };
+    const variables = projectName ? { projectName } : { projectName: "" };
     const data = await queryAPI(query, variables);
     const formattedData = formatRootSpans(data);
     return formattedData;
@@ -119,6 +119,61 @@ const spanKindFormatter = (spanKind: string | null, inputContent: any, outputCon
       });
     }
     
+    return {
+      input: formattedInput,
+      output: formattedOutput
+    };
+  } else if (spanKind === "chain") {
+    console.log('⛓️ Processing Chain span');
+    
+    // Format input: extract content from the last object in the messages array
+    let formattedInput = inputContent;
+    
+    if (inputContent && typeof inputContent === 'object' && inputContent.messages && Array.isArray(inputContent.messages)) {
+      console.log('✅ Found input messages array with', inputContent.messages.length, 'messages');
+      const messages = inputContent.messages;
+      if (messages.length > 0) {
+        const lastMessage = messages[messages.length - 1];
+        console.log('📄 Last input message:', lastMessage);
+        if (lastMessage && lastMessage.content) {
+          formattedInput = lastMessage.content;
+          console.log('✅ Extracted content from last input message');
+        } else {
+          console.log('⚠️ Last input message has no content property');
+        }
+      }
+    } else {
+      console.log('❌ Input is not an object with messages array. Input structure:', {
+        isObject: typeof inputContent === 'object',
+        hasMessages: inputContent?.messages !== undefined,
+        messagesIsArray: Array.isArray(inputContent?.messages)
+      });
+    }
+
+    // Format output: extract content from the last object in the messages array (same as input)
+    let formattedOutput = outputContent;
+    
+    if (outputContent && typeof outputContent === 'object' && outputContent.messages && Array.isArray(outputContent.messages)) {
+      console.log('✅ Found output messages array with', outputContent.messages.length, 'messages');
+      const messages = outputContent.messages;
+      if (messages.length > 0) {
+        const lastMessage = messages[messages.length - 1];
+        console.log('📄 Last output message:', lastMessage);
+        if (lastMessage && lastMessage.content) {
+          formattedOutput = lastMessage.content;
+          console.log('✅ Extracted content from last output message');
+        } else {
+          console.log('⚠️ Last output message has no content property');
+        }
+      }
+    } else {
+      console.log('❌ Output is not an object with messages array. Output structure:', {
+        isObject: typeof outputContent === 'object',
+        hasMessages: outputContent?.messages !== undefined,
+        messagesIsArray: Array.isArray(outputContent?.messages)
+      });
+    }
+
     return {
       input: formattedInput,
       output: formattedOutput

--- a/src/services/graphqlIngestion/fetchRootSpans.ts
+++ b/src/services/graphqlIngestion/fetchRootSpans.ts
@@ -36,7 +36,7 @@ const fetchRootSpans = async (projectName?: string): Promise<RootSpan[]> => {
     }`;
 
     // If projectName is empty it will retrieve all root spans!
-    const variables = projectName ? { projectName } : { projectName: "error analysis app" };
+    const variables = projectName ? { projectName } : { projectName: "recipe-chatbot-oneTrace" };
     const data = await queryAPI(query, variables);
     const formattedData = formatRootSpans(data);
     return formattedData;
@@ -123,8 +123,38 @@ const spanKindFormatter = (spanKind: string | null, inputContent: any, outputCon
       input: formattedInput,
       output: formattedOutput
     };
+  } else if (spanKind === "agent") {
+    console.log('🤖 Processing Agent span');
+    
+    // Format input: extract content from the last object in the array
+    let formattedInput = inputContent;
+    
+    if (inputContent && Array.isArray(inputContent)) {
+      console.log('✅ Found input array with', inputContent.length, 'items');
+      if (inputContent.length > 0) {
+        const lastItem = inputContent[inputContent.length - 1];
+        console.log('📄 Last input item:', lastItem);
+        if (lastItem && lastItem.content) {
+          formattedInput = lastItem.content;
+          console.log('✅ Extracted content from last input item');
+        } else {
+          console.log('⚠️ Last input item has no content property');
+        }
+      }
+    } else {
+      console.log('❌ Input is not an array. Input structure:', {
+        isArray: Array.isArray(inputContent),
+        inputType: typeof inputContent
+      });
+    }
+
+    // For agent spans, keep output as-is (you didn't specify output formatting)
+    return {
+      input: formattedInput,
+      output: outputContent
+    };
   } else {
-    console.log('📋 Processing non-LLM span, returning as-is');
+    console.log('📋 Processing non-LLM/non-Agent span, returning as-is');
   }
   
   // For non-LLM spans, return as-is

--- a/src/services/graphqlIngestion/fetchRootSpans.ts
+++ b/src/services/graphqlIngestion/fetchRootSpans.ts
@@ -148,10 +148,31 @@ const spanKindFormatter = (spanKind: string | null, inputContent: any, outputCon
       });
     }
 
-    // For agent spans, keep output as-is (you didn't specify output formatting)
+    // Format output: extract content from the last object in the array (same as input)
+    let formattedOutput = outputContent;
+    
+    if (outputContent && Array.isArray(outputContent)) {
+      console.log('✅ Found output array with', outputContent.length, 'items');
+      if (outputContent.length > 0) {
+        const lastItem = outputContent[outputContent.length - 1];
+        console.log('📄 Last output item:', lastItem);
+        if (lastItem && lastItem.content) {
+          formattedOutput = lastItem.content;
+          console.log('✅ Extracted content from last output item');
+        } else {
+          console.log('⚠️ Last output item has no content property');
+        }
+      }
+    } else {
+      console.log('❌ Output is not an array. Output structure:', {
+        isArray: Array.isArray(outputContent),
+        outputType: typeof outputContent
+      });
+    }
+
     return {
       input: formattedInput,
-      output: outputContent
+      output: formattedOutput
     };
   } else {
     console.log('📋 Processing non-LLM/non-Agent span, returning as-is');

--- a/src/services/graphqlIngestion/fetchRootSpans.ts
+++ b/src/services/graphqlIngestion/fetchRootSpans.ts
@@ -1,12 +1,11 @@
 import { RootSpan } from "../../types/types";
 import { queryAPI } from "./queryAPI";
 
-const fetchRootSpans = async (projectName?: string) => {
+const fetchRootSpans = async (projectName?: string): Promise<RootSpan[]> => {
   try {
     console.log('Fetching root spans');
-  
-    const query = 
-    `query RootSpans ($projectName: String!){
+    
+    const query = `query RootSpans ($projectName: String!){
       projects (filter: {col: name, value: $projectName}) {
         edges {
           node {
@@ -27,45 +26,132 @@ const fetchRootSpans = async (projectName?: string) => {
                   startTime
                   endTime
                   name
+                  spanKind
                 }
               }
             }
           }
         }
       }
-    }`
+    }`;
 
-    // If projectName is empty it will retreive all root spans!
-    const variables = projectName ? { projectName } : { projectName: "" } ;
+    // If projectName is empty it will retrieve all root spans!
+    const variables = projectName ? { projectName } : { projectName: "" };
     const data = await queryAPI(query, variables);
     const formattedData = formatRootSpans(data);
     return formattedData;
   } catch (error) {
     console.error('Error in fetchRootSpans:', error);
+    return []; // Return empty array instead of undefined
   }
 };
 
-// This is the formatting for our rootSpans where we want the content from the last object in an array.
-const formatRootSpans = (data: any): RootSpan[] => {
-  return data.data.projects.edges.flatMap((project: any) => {
-    return project.node.spans.edges.map((span: any) => {
-      const output = JSON.parse(span.node.output.value);
-      const input = JSON.parse(span.node.input.value);
-      const inputContent = input[input.length - 1].content;
-      const outputContent = output[output.length - 1].content;
+function safeJsonParse(value: string | null | undefined): any {
+  if (!value || typeof value !== 'string') {
+    return value; // Return as-is if not a string
+  }
+  
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value; // Return original string if parsing fails
+  }
+}
 
-      return {
-        id: span.node.context.spanId,
-        traceId: span.node.context.traceId,
-        startTime: span.node.startTime,
-        endTime: span.node.endTime,
-        input: inputContent,
-        output: outputContent,
-        projectName: project.node.name,
-        spanName: span.node.name,
-      };
-    });
+const isValidRootSpan = (rootSpan: any): boolean => {
+  const requiredProps = ['id', 'traceId', 'startTime', 'endTime', 'input', 'output', 'projectName', 'spanName'];
+  
+  return requiredProps.every(prop => {
+    const value = rootSpan[prop];
+    return value !== null && value !== undefined && value !== '';
   });
+};
+
+const formatRootSpans = (data: any): RootSpan[] => {
+  try {
+    if (!data?.data?.projects?.edges) {
+      console.log('No projects data found');
+      return [];
+    }
+
+    const allSpans = data.data.projects.edges.flatMap((project: any) => {
+      if (!project?.node?.spans?.edges) {
+        console.log('No spans found for project:', project?.node?.name);
+        return [];
+      }
+
+      const projectName = project?.node?.name;
+      if (!projectName) {
+        console.warn('Project missing name, skipping');
+        return [];
+      }
+
+      return project.node.spans.edges
+        .map((span: any) => {
+          try {
+            const spanNode = span?.node;
+            if (!spanNode) {
+              console.warn('Span node is missing, skipping');
+              return null;
+            }
+
+            const context = spanNode?.context;
+            if (!context?.spanId || !context?.traceId) {
+              console.warn('Span missing required context (spanId/traceId), skipping');
+              return null;
+            }
+
+            console.log('Processing span:', context.spanId);
+            
+            // Safe access and JSON parsing
+            const inputValue = spanNode?.input?.value;
+            const outputValue = spanNode?.output?.value;
+            
+            const inputContent = safeJsonParse(inputValue);
+            const outputContent = safeJsonParse(outputValue);
+            
+            return {
+              id: context.spanId,
+              traceId: context.traceId,
+              startTime: spanNode?.startTime || null,
+              endTime: spanNode?.endTime || null,
+              input: inputContent,
+              output: outputContent,
+              projectName: projectName,
+              spanName: spanNode?.name || null,
+            };
+          } catch (spanError) {
+            console.error('Error processing individual span:', spanError);
+            return null; // Return null for failed spans
+          }
+        })
+        .filter((rootSpan: any) => {
+          if (rootSpan === null) {
+            return false; // Filter out failed spans
+          }
+          
+          const valid = isValidRootSpan(rootSpan);
+          if (!valid) {
+            console.warn('Filtered out incomplete span:', {
+              id: rootSpan?.id,
+              hasInput: rootSpan?.input !== null && rootSpan?.input !== undefined,
+              hasOutput: rootSpan?.output !== null && rootSpan?.output !== undefined,
+              hasStartTime: !!rootSpan?.startTime,
+              hasEndTime: !!rootSpan?.endTime,
+              hasSpanName: !!rootSpan?.spanName
+            });
+          }
+          return valid;
+        });
+    });
+
+    console.log(`Processed ${allSpans.length} valid root spans`);
+    return allSpans;
+
+  } catch (error) {
+    console.error('Error in formatRootSpans:', error);
+    return []; // Return empty array on any formatting error
+  }
 };
 
 export default fetchRootSpans;


### PR DESCRIPTION
quick note
- in the server.ts file, at the top it has populateAllMockData().   This actually resets the annotations and rootspans databases.  So every time you restart the server, it reingests all of the root spans.   This can be commented out if you want to keep annotations or rootspans.

features
- fetchRootSpans.ts now has safeJsonParse.  It tries to parse the input and output as if it is json.  If it is not json, it just keeps the input/output how it is
- the graphQL query now also fetches the spanKind.  This is what tells this file how to format the input/output
- spanKindFormatter function is doing the majority of the work.  It formats the input/out differently if it is an "llm" "agent" "chain" or other.  
- Everything inside our phoenix dashboard works right now.  However, we certainly need to test other input/output types and possibly update this file.  
- The code has a lot of console.logs.  This was done so that I could validate what was working and what wasn't.  There was not enough documentation to do this without a lot of trial and error.
- I used AI to help make some of these functions.  As you can tell by the clear AI signs.  Will be worth going through this all later and adjusting to our own code style. 
- Right now everything is formatted based on the spanKind.  One idea I had was that maybe we make it so that on the front end, the user can choose a few formatting options.  I do not know yet if spanKinda are consistently going to be in these formats or if that's just the data we have right now in Phoenix.  